### PR TITLE
Twitter api 2.0

### DIFF
--- a/lib/newsScreen/news_screen.dart
+++ b/lib/newsScreen/news_screen.dart
@@ -40,17 +40,20 @@ class _ListOfNewsState extends State<ListOfNews> {
                 onPageChanged: onPageChanged,
                 controller: controller,
                 children: [
-                  ListView.builder(
-                    itemBuilder: (context, index) {
-                      return myCard(index);
-                    },
-                    itemCount:
-                        Provider.of<TwietterApiProvider>(context, listen: false)
-                            .listOfTweets
-                            .length,
-                  ),
-                  Meme_list(),
+                  Text(Provider.of<TwietterApiProvider>(context).test)
                 ],
+                // children: [
+                //   ListView.builder(
+                //     itemBuilder: (context, index) {
+                //       return myCard(index);
+                //     },
+                //     itemCount:
+                //         Provider.of<TwietterApiProvider>(context, listen: false)
+                //             .listOfTweets
+                //             .length,
+                //   ),
+                //   Meme_list(),
+                // ],
               ),
             ),
           ],

--- a/lib/newsScreen/news_screen.dart
+++ b/lib/newsScreen/news_screen.dart
@@ -39,21 +39,22 @@ class _ListOfNewsState extends State<ListOfNews> {
               child: PageView(
                 onPageChanged: onPageChanged,
                 controller: controller,
-                children: [
-                  Text(Provider.of<TwietterApiProvider>(context).test)
-                ],
                 // children: [
-                //   ListView.builder(
-                //     itemBuilder: (context, index) {
-                //       return myCard(index);
-                //     },
-                //     itemCount:
-                //         Provider.of<TwietterApiProvider>(context, listen: false)
-                //             .listOfTweets
-                //             .length,
-                //   ),
-                //   Meme_list(),
+                //   Text(
+                //       Provider.of<TwietterApiProvider>(context).test.toString())
                 // ],
+                children: [
+                  ListView.builder(
+                    itemBuilder: (context, index) {
+                      return myCard(index);
+                    },
+                    itemCount:
+                        Provider.of<TwietterApiProvider>(context, listen: false)
+                            .listOfTweets
+                            .length,
+                  ),
+                  Meme_list(),
+                ],
               ),
             ),
           ],

--- a/lib/newsScreen/news_screen.dart
+++ b/lib/newsScreen/news_screen.dart
@@ -64,6 +64,8 @@ class _ListOfNewsState extends State<ListOfNews> {
   }
 
   Widget myCard(index) {
+    var myProvider = Provider.of<TwietterApiProvider>(context, listen: false)
+        .listOfTweets[index];
     return Dismissible(
         key: UniqueKey(),
         onDismissed: (kierunkowy) {
@@ -75,11 +77,10 @@ class _ListOfNewsState extends State<ListOfNews> {
           }
         },
         child: OneNews(
-            screenName: Provider.of<TwietterApiProvider>(context, listen: false)
-                .listOfTweets[index]["user"]["screen_name"],
-            userName: Provider.of<TwietterApiProvider>(context, listen: false)
-                .listOfTweets[index]["user"]["name"],
-            tweetTxt: Provider.of<TwietterApiProvider>(context, listen: false)
-                .listOfTweets[index]["full_text"]));
+            tweetUrl:
+                "https://twitter.com/${myProvider["user"]["screen_name"]}/status/${myProvider["id"]}",
+            screenName: myProvider["user"]["screen_name"],
+            userName: myProvider["user"]["name"],
+            tweetTxt: myProvider["full_text"]));
   }
 }

--- a/lib/newsScreen/one_news_screen.dart
+++ b/lib/newsScreen/one_news_screen.dart
@@ -11,10 +11,12 @@ class OneNews extends StatefulWidget {
     required this.tweetTxt,
     required this.userName,
     required this.screenName,
+    required this.tweetUrl,
   }) : super(key: key);
   final String tweetTxt;
   final String userName;
   final String screenName;
+  final String tweetUrl;
 
   @override
   State<OneNews> createState() => _OneNewsState();
@@ -51,7 +53,7 @@ class _OneNewsState extends State<OneNews> {
                         " @" +
                             widget.screenName +
                             "eeeeeeeeeeeeeeeeeerrrrrrrraaaaaaaaaa",
-                        overflow: TextOverflow.fade,
+                        overflow: TextOverflow.ellipsis,
                         maxLines: 1,
                       ),
                     )
@@ -62,7 +64,7 @@ class _OneNewsState extends State<OneNews> {
                 child: InkWell(
                   onTap: () {
                     Provider.of<TwietterApiProvider>(context, listen: false)
-                        .launchURL();
+                        .launchURL(widget.tweetUrl);
                   },
                   child: Padding(
                     padding: const EdgeInsets.all(8.0),

--- a/lib/provider/twitter_api_provider.dart
+++ b/lib/provider/twitter_api_provider.dart
@@ -13,6 +13,7 @@ class TwietterApiProvider extends ChangeNotifier {
     notifyListeners();
   }
 
+  var test;
   TwietterApiProvider() {
     _init();
   }
@@ -56,9 +57,10 @@ class TwietterApiProvider extends ChangeNotifier {
           List<Map<String, dynamic>>.from(json.decode(response.body));
 
       data.forEach((tweet) => _listOfTweets.add(tweet));
-      // print(_listOfTweets);
+      test = _listOfTweets[0];
 
       notifyListeners();
+      print(_listOfTweets);
     } catch (error) {
       print('error while requesting home timeline: $error');
     }

--- a/lib/provider/twitter_api_provider.dart
+++ b/lib/provider/twitter_api_provider.dart
@@ -32,10 +32,11 @@ class TwietterApiProvider extends ChangeNotifier {
 
   launchURL() async {
     for (var index in _listOfTweets) {
-      List<Map> myUrls = listOfTweets[index]["entities"]["urls"];
-      String url = myUrls[0]["url"];
+      String url =
+          _listOfTweets[0]["extended_entities"]["media"][0]["expanded_url"];
       if (await canLaunch(url)) {
         await launch(url);
+        print(url);
         notifyListeners();
       } else {
         throw 'Could not launch $url';
@@ -57,10 +58,10 @@ class TwietterApiProvider extends ChangeNotifier {
           List<Map<String, dynamic>>.from(json.decode(response.body));
 
       data.forEach((tweet) => _listOfTweets.add(tweet));
-      test = _listOfTweets[0];
+      test = _listOfTweets[0]["extended_entities"]["media"][0]["expanded_url"];
 
       notifyListeners();
-      print(_listOfTweets);
+      // print(test);
     } catch (error) {
       print('error while requesting home timeline: $error');
     }

--- a/lib/provider/twitter_api_provider.dart
+++ b/lib/provider/twitter_api_provider.dart
@@ -30,18 +30,17 @@ class TwietterApiProvider extends ChangeNotifier {
     _getData();
   }
 
-  launchURL() async {
-    for (var index in _listOfTweets) {
-      String url =
-          _listOfTweets[0]["extended_entities"]["media"][0]["expanded_url"];
-      if (await canLaunch(url)) {
-        await launch(url);
-        print(url);
-        notifyListeners();
-      } else {
-        throw 'Could not launch $url';
-      }
+  launchURL(url) async {
+    // for (var index in _listOfTweets) {
+    //String url = _listOfTweets[index]["extended_entities"]["media"][0]["expanded_url"];
+    if (await canLaunch(url)) {
+      await launch(url);
+      print(url);
+      notifyListeners();
+    } else {
+      throw 'Could not launch $url';
     }
+    // }
   }
 
   Future<void> _getData() async {
@@ -51,14 +50,15 @@ class TwietterApiProvider extends ChangeNotifier {
           '1.1/statuses/home_timeline.json', <String, String>{
         'count': '7',
         'tweet_mode': 'extended',
-        'include_entities': 'false',
+        'include_entities': 'true',
       }));
       var res = response.body;
       List<Map<String, dynamic>> data =
           List<Map<String, dynamic>>.from(json.decode(response.body));
 
       data.forEach((tweet) => _listOfTweets.add(tweet));
-      test = _listOfTweets[0]["extended_entities"]["media"][0]["expanded_url"];
+      test = _listOfTweets[0]["entities"];
+      print(_listOfTweets[0]["entities"]);
 
       notifyListeners();
       // print(test);


### PR DESCRIPTION
Przejście do tweeta  na przeglądarkę poprzez kliknięcie karty.
Problem polegał na tym, że w zależności od tego czy to był retweet, czy zawierał jakieś media, typu zdjęcie, video, itp., odpowiedź Twitter API miała inną konstrukcję.
Rozwiązałam to na betona, składając url do tweeta ze stałych elementów, które są niezależne od typu odpowiedzi.